### PR TITLE
Fix homepage url in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
-url = https://github.com/ashwinvis/xrandr_extend
+url = https://github.com/ashwinvis/xrandr-extend
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
The project homepage link to this GitHub repo on [pypi](https://pypi.org/project/xrandr-extend/) is 404. This should fix it :)